### PR TITLE
Enhance cross spreads with multi-leg ratios and add unit conversions

### DIFF
--- a/CTAFlow/data/contract_handling/__init__.py
+++ b/CTAFlow/data/contract_handling/__init__.py
@@ -1,9 +1,21 @@
-from .curve_manager import Contract, SpreadData, SpreadFeature, SeqData, SpreadReturns, FuturesCurveManager, ExpiryTracker
+from .curve_manager import (
+    Contract,
+    CrossProductSpreadData,
+    CrossSpreadLeg,
+    SpreadData,
+    SpreadFeature,
+    SeqData,
+    SpreadReturns,
+    FuturesCurveManager,
+    ExpiryTracker,
+)
 from .roll_date_manager import RollDateManager, create_enhanced_curve_manager_with_roll_tracking
 
 __all__ = [
     "Contract",
     "SeqData",
+    "CrossProductSpreadData",
+    "CrossSpreadLeg",
     "SpreadData",
     "ExpiryTracker",
     "SpreadReturns",

--- a/CTAFlow/utils/__init__.py
+++ b/CTAFlow/utils/__init__.py
@@ -1,9 +1,19 @@
 """Utility functions for model/math operations."""
 
 from .seasonal import deseasonalize_monthly, zscore_normalize, SeasonalAnalysis
+from .unit_conversions import (
+    gallons_to_barrels,
+    barrels_to_gallons,
+    bushels_to_kilograms,
+    bushels_to_metric_tons,
+)
 
 __all__ = [
     "deseasonalize_monthly",
     "zscore_normalize",
     "SeasonalAnalysis",
+    "gallons_to_barrels",
+    "barrels_to_gallons",
+    "bushels_to_kilograms",
+    "bushels_to_metric_tons",
 ]

--- a/CTAFlow/utils/tenor_interpolation.py
+++ b/CTAFlow/utils/tenor_interpolation.py
@@ -65,15 +65,16 @@ def log_interp_to_tau(
         avail = row.dropna()
         if avail.empty:
             continue
-            
-        # Calculate time to maturity in years
-        T = (expiries.loc[avail.index].values - pd.Timestamp(t)).days / 365.25
+
+        expiry_values = pd.to_datetime(expiries.loc[avail.index])
+        T = (expiry_values - pd.Timestamp(t)).dt.days / 365.25
         lnF = np.log(avail.values.astype(float))
         
         # Sort by time to maturity
-        order = np.argsort(T)
-        T = T[order]
-        lnF = lnF[order]
+        T_array = T.to_numpy()
+        order = np.argsort(T_array)
+        T = T_array[order]
+        lnF = np.asarray(lnF)[order]
         
         # Interpolate for each target tau
         for tau in taus:

--- a/CTAFlow/utils/unit_conversions.py
+++ b/CTAFlow/utils/unit_conversions.py
@@ -1,0 +1,96 @@
+"""Commodity unit conversion helpers used throughout CTA analytics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+
+GALLONS_PER_BARREL = 42.0
+POUNDS_TO_KG = 0.45359237
+
+_BUSHEL_WEIGHT_LBS: Dict[str, float] = {
+    "corn": 56.0,
+    "soybean": 60.0,
+    "wheat": 60.0,
+    "oat": 32.0,
+    "barley": 48.0,
+    "canola": 50.0,
+    "sorghum": 56.0,
+    "rice": 45.0,
+}
+
+_COMMODITY_ALIASES: Dict[str, str] = {
+    "soybeans": "soybean",
+    "soya": "soybean",
+    "bean": "soybean",
+    "beans": "soybean",
+    "oats": "oat",
+    "barleys": "barley",
+    "corns": "corn",
+    "rices": "rice",
+    "sorghums": "sorghum",
+    "canolas": "canola",
+}
+
+
+def _apply_conversion(value: Any, factor: float):
+    """Apply a multiplicative conversion factor while preserving the input structure."""
+    if isinstance(value, pd.Series):
+        return value.astype(float) * factor
+    if isinstance(value, pd.DataFrame):
+        return value.astype(float) * factor
+    if np.isscalar(value):
+        return float(value) * factor
+    array = np.asarray(value, dtype=float)
+    return array * factor
+
+
+def gallons_to_barrels(gallons: Any):
+    """Convert gallons to barrels (42 gallons per barrel)."""
+    return _apply_conversion(gallons, 1.0 / GALLONS_PER_BARREL)
+
+
+def barrels_to_gallons(barrels: Any):
+    """Convert barrels to gallons."""
+    return _apply_conversion(barrels, GALLONS_PER_BARREL)
+
+
+def _normalize_commodity(commodity: str) -> str:
+    if not isinstance(commodity, str):
+        raise TypeError("Commodity name must be provided as a string")
+
+    key = commodity.strip().lower().replace(" ", "").replace("-", "")
+    key = _COMMODITY_ALIASES.get(key, key)
+
+    if key not in _BUSHEL_WEIGHT_LBS and key.endswith("s"):
+        singular = key[:-1]
+        if singular in _BUSHEL_WEIGHT_LBS:
+            key = singular
+
+    if key not in _BUSHEL_WEIGHT_LBS:
+        raise KeyError(f"Unsupported commodity for bushel conversion: {commodity}")
+
+    return key
+
+
+def bushels_to_kilograms(bushels: Any, commodity: str):
+    """Convert bushels of a commodity to kilograms."""
+    key = _normalize_commodity(commodity)
+    kilograms_per_bushel = _BUSHEL_WEIGHT_LBS[key] * POUNDS_TO_KG
+    return _apply_conversion(bushels, kilograms_per_bushel)
+
+
+def bushels_to_metric_tons(bushels: Any, commodity: str):
+    """Convert bushels of a commodity to metric tons."""
+    kilograms = bushels_to_kilograms(bushels, commodity)
+    return kilograms / 1000.0
+
+
+__all__ = [
+    "gallons_to_barrels",
+    "barrels_to_gallons",
+    "bushels_to_kilograms",
+    "bushels_to_metric_tons",
+]

--- a/test_cross_product_spread_data.py
+++ b/test_cross_product_spread_data.py
@@ -1,0 +1,240 @@
+import importlib.util
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parent
+PACKAGE_ROOT = ROOT / "CTAFlow"
+
+
+@contextmanager
+def load_curve_manager_with_stubs():
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+    stub_names = [
+        "CTAFlow",
+        "CTAFlow.config",
+        "CTAFlow.data",
+        "CTAFlow.data.data_client",
+        "CTAFlow.data.contract_handling",
+        "CTAFlow.data.contract_handling.curve_manager",
+        "CTAFlow.utils.tenor_interpolation",
+    ]
+
+    original_modules = {name: sys.modules.get(name) for name in stub_names}
+
+    try:
+        cta_pkg = types.ModuleType("CTAFlow")
+        cta_pkg.__path__ = [str(PACKAGE_ROOT)]
+        sys.modules["CTAFlow"] = cta_pkg
+
+        config_stub = types.ModuleType("CTAFlow.config")
+        config_stub.RAW_MARKET_DATA_PATH = Path(".")
+        config_stub.MARKET_DATA_PATH = Path("./market_data.h5")
+        sys.modules["CTAFlow.config"] = config_stub
+
+        data_pkg = types.ModuleType("CTAFlow.data")
+        data_pkg.__path__ = []
+        sys.modules["CTAFlow.data"] = data_pkg
+
+        data_client_stub = types.ModuleType("CTAFlow.data.data_client")
+
+        class _StubDataClient:  # pragma: no cover - simple stub
+            def query_curve_data(self, *args, **kwargs):
+                return {}
+
+            def read_roll_dates(self, *args, **kwargs):
+                raise KeyError("no roll data in stub")
+
+        data_client_stub.DataClient = _StubDataClient
+        sys.modules["CTAFlow.data.data_client"] = data_client_stub
+
+        contract_pkg = types.ModuleType("CTAFlow.data.contract_handling")
+        contract_pkg.__path__ = []
+        sys.modules["CTAFlow.data.contract_handling"] = contract_pkg
+
+        curve_manager_path = PACKAGE_ROOT / "data" / "contract_handling" / "curve_manager.py"
+        spec = importlib.util.spec_from_file_location(
+            "CTAFlow.data.contract_handling.curve_manager", curve_manager_path
+        )
+        curve_manager = importlib.util.module_from_spec(spec)
+        sys.modules["CTAFlow.data.contract_handling.curve_manager"] = curve_manager
+        spec.loader.exec_module(curve_manager)
+
+        tenor_path = PACKAGE_ROOT / "utils" / "tenor_interpolation.py"
+        tenor_spec = importlib.util.spec_from_file_location(
+            "CTAFlow.utils.tenor_interpolation", tenor_path
+        )
+        tenor_module = importlib.util.module_from_spec(tenor_spec)
+        sys.modules["CTAFlow.utils.tenor_interpolation"] = tenor_module
+        tenor_spec.loader.exec_module(tenor_module)
+
+        yield curve_manager, tenor_module
+
+    finally:
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_spread_data_utils_interfaces():
+    with load_curve_manager_with_stubs() as (curve_manager, tenor_module):
+        SpreadData = curve_manager.SpreadData
+        log_interp_to_tau = tenor_module.log_interp_to_tau
+
+        np.random.seed(0)
+        spread = SpreadData.example()
+
+        seq_prices = spread.get_sequential_prices()
+        assert isinstance(seq_prices, pd.DataFrame)
+        assert not seq_prices.empty
+
+        prices, expiries = spread.get_constant_maturity_inputs()
+        assert isinstance(prices, pd.DataFrame)
+        assert isinstance(expiries, pd.Series)
+        assert not prices.empty
+        assert not expiries.empty
+
+        taus = np.array([1 / 12, 0.5, 1.0])
+        interpolated = log_interp_to_tau(prices, expiries, taus)
+        assert set(interpolated.keys()) == set(taus)
+        for series in interpolated.values():
+            assert isinstance(series, pd.Series)
+
+
+def test_cross_product_spread_data_differences():
+    with load_curve_manager_with_stubs() as (curve_manager, tenor_module):
+        SpreadData = curve_manager.SpreadData
+        CrossProductSpreadData = curve_manager.CrossProductSpreadData
+
+        np.random.seed(1)
+        base = SpreadData.example()
+        np.random.seed(2)
+        hedge = SpreadData.example()
+
+        cross = CrossProductSpreadData(base, hedge)
+        df = cross.to_dataframe()
+        assert not df.empty
+        assert list(df.columns) == cross.columns
+
+        m0_spread = cross.get_contract_spread('M0')
+        assert isinstance(m0_spread, pd.Series)
+        assert len(m0_spread) == len(cross.index)
+
+        front = cross.get_front_spread()
+        assert front is not None
+
+        summary = cross.describe()
+        assert summary['pair'] == cross.pair_label
+        assert 'mean_spread' in summary and 'std_spread' in summary
+        assert len(summary['legs']) == 2
+
+        leg_labels = cross.leg_labels
+        assert leg_labels[0].startswith('EXAMPLE')
+        assert leg_labels[1] != leg_labels[0]
+
+        weights = cross.get_leg_weights()
+        assert set(weights.keys()) == set(leg_labels)
+
+        first_leg_label = leg_labels[0]
+        second_leg_label = leg_labels[1]
+
+        first_contribution = cross.get_leg_contribution(first_leg_label)
+        second_contribution = cross.get_leg_contribution(summary['legs'][1]['source_label'])
+
+        assert isinstance(first_contribution, pd.DataFrame)
+        assert isinstance(second_contribution, pd.DataFrame)
+
+        assert summary['legs'][0]['source_label'] == cross.leg_label_map[first_leg_label]
+        assert summary['legs'][1]['source_label'] == cross.leg_label_map[second_leg_label]
+
+
+def test_cross_product_spread_multi_leg_ratios():
+    with load_curve_manager_with_stubs() as (curve_manager, _):
+        SpreadData = curve_manager.SpreadData
+        CrossProductSpreadData = curve_manager.CrossProductSpreadData
+        CrossSpreadLeg = curve_manager.CrossSpreadLeg
+
+        np.random.seed(3)
+        oil = SpreadData.example()
+        np.random.seed(4)
+        gasoline = SpreadData.example()
+        np.random.seed(5)
+        heating_oil = SpreadData.example()
+
+        crack = CrossProductSpreadData(
+            base=oil,
+            hedge=gasoline,
+            base_ratio=3.0,
+            hedge_ratio=-2.0,
+            additional_legs=[CrossSpreadLeg(data=heating_oil, ratio=-1.0, label="HeatingOil")],
+        )
+
+        crack_df = crack.to_dataframe()
+        assert not crack_df.empty
+
+        base_prices = oil.get_sequential_prices(dropna=False).reindex(
+            index=crack_df.index,
+            columns=crack_df.columns,
+        )
+        gas_prices = gasoline.get_sequential_prices(dropna=False).reindex(
+            index=crack_df.index,
+            columns=crack_df.columns,
+        )
+        heat_prices = heating_oil.get_sequential_prices(dropna=False).reindex(
+            index=crack_df.index,
+            columns=crack_df.columns,
+        )
+
+        expected = (base_prices * 3.0) + (gas_prices * -2.0) + (heat_prices * -1.0)
+        pd.testing.assert_frame_equal(crack_df, expected)
+
+        summary = crack.describe()
+        assert len(summary['legs']) == 3
+        heating_leg = next(leg for leg in summary['legs'] if leg['source_label'] == 'HeatingOil')
+        assert heating_leg['ratio'] == -1.0
+
+        contributions = crack.get_leg_contribution('HeatingOil')
+        pd.testing.assert_frame_equal(contributions, heat_prices * -1.0)
+
+
+def test_cross_product_spread_contract_overrides():
+    with load_curve_manager_with_stubs() as (curve_manager, _):
+        SpreadData = curve_manager.SpreadData
+        CrossProductSpreadData = curve_manager.CrossProductSpreadData
+
+        np.random.seed(6)
+        base = SpreadData.example()
+        np.random.seed(7)
+        hedge = SpreadData.example()
+
+        override_spread = CrossProductSpreadData(
+            base=base,
+            hedge=hedge,
+            hedge_contract_ratios={'M0': -2.0, 'M1': -0.5},
+        )
+
+        override_df = override_spread.to_dataframe()
+        base_prices = base.get_sequential_prices(dropna=False).reindex(
+            index=override_df.index,
+            columns=override_df.columns,
+        )
+        hedge_prices = hedge.get_sequential_prices(dropna=False).reindex(
+            index=override_df.index,
+            columns=override_df.columns,
+        )
+
+        hedge_label = override_spread.leg_labels[1]
+        hedge_weights = pd.Series(override_spread.get_leg_weights()[hedge_label])
+        expected_override = base_prices + hedge_prices.multiply(hedge_weights, axis=1)
+
+        pd.testing.assert_frame_equal(override_df, expected_override)
+        assert hedge_weights['M0'] == -2.0
+        assert hedge_weights['M1'] == -0.5

--- a/test_curve_evolution_analyzer.py
+++ b/test_curve_evolution_analyzer.py
@@ -43,8 +43,6 @@ stub.MONTH_CODE_MAP = {c: i + 1 for i, c in enumerate('FGHJKMNQUVXZ')}
 
 cta_pkg = types.ModuleType("CTAFlow")
 cta_pkg.__path__ = [str(Path(__file__).resolve().parent)]
-=======
-cta_pkg.__path__ = []
 features_pkg = types.ModuleType("CTAFlow.features")
 features_pkg.__path__ = []
 data_pkg = types.ModuleType("CTAFlow.data")

--- a/test_unit_conversions.py
+++ b/test_unit_conversions.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MODULE_PATH = ROOT / "CTAFlow" / "utils" / "unit_conversions.py"
+spec = importlib.util.spec_from_file_location("CTAFlow.utils.unit_conversions", MODULE_PATH)
+unit_conversions = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(unit_conversions)
+
+gallons_to_barrels = unit_conversions.gallons_to_barrels
+barrels_to_gallons = unit_conversions.barrels_to_gallons
+bushels_to_kilograms = unit_conversions.bushels_to_kilograms
+bushels_to_metric_tons = unit_conversions.bushels_to_metric_tons
+
+
+def test_gallons_barrels_conversion():
+    assert gallons_to_barrels(42) == pytest.approx(1.0)
+    assert barrels_to_gallons(1) == pytest.approx(42.0)
+
+    array_result = gallons_to_barrels(np.array([0, 84]))
+    np.testing.assert_allclose(array_result, np.array([0.0, 2.0]))
+
+    series = pd.Series([42, 84], name="volume")
+    barrels_series = gallons_to_barrels(series)
+    expected_series = pd.Series([1.0, 2.0], name="volume")
+    pd.testing.assert_series_equal(barrels_series, expected_series)
+
+
+def test_bushels_conversions():
+    corn_kg = bushels_to_kilograms(2, "corn")
+    assert corn_kg == pytest.approx(2 * 56.0 * 0.45359237)
+
+    soy_series = pd.Series([1, 2], name="soy")
+    soy_tons = bushels_to_metric_tons(soy_series, "soybeans")
+    expected_tons = soy_series.astype(float) * 60.0 * 0.45359237 / 1000.0
+    pd.testing.assert_series_equal(soy_tons, expected_tons)
+
+    with pytest.raises(KeyError):
+        bushels_to_kilograms(1, "unknown")
+
+    with pytest.raises(TypeError):
+        bushels_to_metric_tons(1, 123)


### PR DESCRIPTION
## Summary
- extend `CrossProductSpreadData` with a new `CrossSpreadLeg` helper so cross-asset spreads can combine multiple legs with custom ratios and per-contract weights, and expose contribution/weight metadata
- export commodity unit conversions via a new `CTAFlow.utils.unit_conversions` module and surface them through the utils package
- add regression tests covering multi-leg crack spreads, contract override weights, and the new conversion helpers

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8c8aa23c8832a98ba59996ff59476