### PR TITLE
Avoid enumerating HDF keys when querying curves

### DIFF
--- a/CTAFlow/data/data_client.py
+++ b/CTAFlow/data/data_client.py
@@ -995,12 +995,10 @@ class DataClient:
 
         try:
             with pd.HDFStore(self.market_path, "r") as store:
-                store_keys = {k.lstrip("/") for k in store.keys()}
-
                 for curve_type in curve_types_to_query:
                     market_key = f"market/{available_curve_types[curve_type]}"
 
-                    if market_key not in store_keys:
+                    if market_key not in store:
                         print(f"Warning: {market_key} not found in available data")
                         continue
 
@@ -1011,6 +1009,9 @@ class DataClient:
                             columns=columns
                         )
                         results[curve_type] = df
+                    except KeyError:
+                        print(f"Warning: {market_key} not found in available data")
+                        continue
                     except Exception as e:
                         print(f"Error querying {market_key}: {e}")
                         continue


### PR DESCRIPTION
## Summary
- stop building a full set of keys when querying curve datasets
- rely on direct store membership tests and targeted error handling to keep warnings for missing data without enumerating all keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae7f50f28832a85638e7bbd51a6f4