### PR TITLE
Fix timezone localization helper and add regression test

### DIFF
--- a/CTAFlow/screeners/historical_screener.py
+++ b/CTAFlow/screeners/historical_screener.py
@@ -3155,7 +3155,9 @@ class HistoricalScreener:
         if data is None or data.empty or not tz:
             return data
 
-        target_tz = pd.Index([], dtype='datetime64[ns]', tz=tz).tz
+        # pd.Index does not guarantee timezone-aware construction across pandas versions;
+        # use DatetimeIndex to reliably materialize the target timezone object.
+        target_tz = pd.DatetimeIndex([], tz=tz).tz
 
         idx = data.index if isinstance(data.index, pd.DatetimeIndex) else pd.to_datetime(data.index, errors='coerce')
 

--- a/tests/test_historical_screener.py
+++ b/tests/test_historical_screener.py
@@ -117,6 +117,22 @@ def historical_screener(example_dataframe):
     return HistoricalScreener({"HO": example_dataframe}, file_mgr=None, verbose=False)
 
 
+def test_localize_dataframe_converts_intraday_index_and_ts(historical_screener):
+    screener = historical_screener
+    tz = "America/Chicago"
+
+    utc_index = pd.date_range("2024-05-01 12:00", periods=3, freq="h", tz="UTC")
+    df = pd.DataFrame({"ts": utc_index, "Close": np.arange(len(utc_index))}, index=utc_index)
+
+    localized = screener._localize_dataframe(df, tz)
+
+    expected_index = utc_index.tz_convert(tz)
+    pd.testing.assert_index_equal(localized.index, expected_index)
+
+    expected_ts = pd.Series(utc_index.tz_convert(tz), index=expected_index, name="ts")
+    pd.testing.assert_series_equal(localized["ts"], expected_ts)
+
+
 def test_run_screens_returns_patterns_structure(historical_screener):
     from CTAFlow.screeners.historical_screener import ScreenParams
 


### PR DESCRIPTION
## Summary
- ensure timezone detection in _localize_dataframe uses a timezone-aware DatetimeIndex to avoid pandas Index construction errors
- add a regression test covering intraday tz conversion for the localization helper

## Testing
- python -m pytest tests/test_historical_screener.py -k localize_dataframe --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ba9c590f0832a85192438ebb61650)