### PR TITLE
Simplify timezone target detection

### DIFF
--- a/CTAFlow/screeners/historical_screener.py
+++ b/CTAFlow/screeners/historical_screener.py
@@ -3155,7 +3155,13 @@ class HistoricalScreener:
         if data is None or data.empty or not tz:
             return data
 
-        target_tz = pd.Index([], dtype='datetime64[ns]', tz=tz).tz
+        # pd.Index/DatetimeIndex construction can raise across pandas versions. Prefer a
+        # lightweight tzinfo derived from ``Timestamp.now`` and fall back to the raw
+        # input to avoid constructing empty indexes with ``tz=``.
+        try:
+            target_tz = pd.Timestamp.now(tz).tz
+        except Exception:
+            target_tz = tz
 
         idx = data.index if isinstance(data.index, pd.DatetimeIndex) else pd.to_datetime(data.index, errors='coerce')
 

--- a/tests/test_historical_screener.py
+++ b/tests/test_historical_screener.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+from dateutil import tz
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -115,6 +116,38 @@ def historical_screener(example_dataframe):
     from CTAFlow.screeners.historical_screener import HistoricalScreener
 
     return HistoricalScreener({"HO": example_dataframe}, file_mgr=None, verbose=False)
+
+
+def test_localize_dataframe_converts_intraday_index_and_ts(historical_screener):
+    screener = historical_screener
+    tz = "America/Chicago"
+
+    utc_index = pd.date_range("2024-05-01 12:00", periods=3, freq="h", tz="UTC")
+    df = pd.DataFrame({"ts": utc_index, "Close": np.arange(len(utc_index))}, index=utc_index)
+
+    localized = screener._localize_dataframe(df, tz)
+
+    expected_index = utc_index.tz_convert(tz)
+    pd.testing.assert_index_equal(localized.index, expected_index)
+
+    expected_ts = pd.Series(utc_index.tz_convert(tz), index=expected_index, name="ts")
+    pd.testing.assert_series_equal(localized["ts"], expected_ts)
+
+
+def test_localize_dataframe_accepts_tzinfo_object(historical_screener):
+    screener = historical_screener
+    tzinfo = tz.gettz("America/Chicago")
+
+    utc_index = pd.date_range("2024-06-01 00:00", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame({"ts": utc_index, "Close": np.arange(len(utc_index))}, index=utc_index)
+
+    localized = screener._localize_dataframe(df, tzinfo)
+
+    expected_index = utc_index.tz_convert(tzinfo)
+    pd.testing.assert_index_equal(localized.index, expected_index)
+
+    expected_ts = pd.Series(expected_index, index=expected_index, name="ts")
+    pd.testing.assert_series_equal(localized["ts"], expected_ts)
 
 
 def test_run_screens_returns_patterns_structure(historical_screener):


### PR DESCRIPTION
## Summary
- derive the target timezone from Timestamp.now to avoid Index construction that fails on some pandas versions
- keep localization logic for both the index and ts columns intact

## Testing
- python -m pytest tests/test_historical_screener.py -k localize_dataframe --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ba9c590f0832a85192438ebb61650)