### PR TITLE
Add GPU support and event calendar generation

### DIFF
--- a/CTAFlow/screeners/event_engine.py
+++ b/CTAFlow/screeners/event_engine.py
@@ -3,7 +3,8 @@ Event screener engine delegating to :mod:`CTAFlow.screeners.event_screener`.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, List, Optional
+from datetime import date
 
 import pandas as pd
 
@@ -12,6 +13,12 @@ from .params import BaseScreenParams, EventParams
 from .screener_types import SCREEN_EVENT
 from .event_screener import run_event_screener
 from ..features.regime_classification import BaseRegimeClassifier
+from .event_presets import (
+    EventDefinition,
+    event_release_dt_for_date,
+    get_events_for_ticker,
+    is_matching_event_slot,
+)
 
 
 class EventScreenEngine(BaseScreenEngine):
@@ -22,10 +29,14 @@ class EventScreenEngine(BaseScreenEngine):
     def __init__(
         self,
         event_calendars: Optional[Dict[str, pd.DataFrame]] = None,
+        event_definitions: Optional[Dict[str, Iterable[EventDefinition]]] = None,
         default_tz: str = "America/Chicago",
         orderflow_provider=None,
     ) -> None:
         self.event_calendars = event_calendars or {}
+        self.event_definitions = {
+            key: list(defs) for key, defs in (event_definitions or {}).items()
+        }
         self.default_tz = default_tz
         self.orderflow_provider = orderflow_provider
 
@@ -37,6 +48,10 @@ class EventScreenEngine(BaseScreenEngine):
         regime_classifier: Optional[BaseRegimeClassifier] = None,
     ) -> Dict[str, Any]:
         events = self.event_calendars.get(ticker) or self.event_calendars.get("default", pd.DataFrame())
+        if events.empty:
+            events = self._generate_events_from_definitions(ticker, data, params)
+            if not events.empty:
+                self.event_calendars[ticker] = events
         context: Dict[str, Any] = {"events": events}
         if isinstance(params, EventParams) and params.use_orderflow and self.orderflow_provider:
             context["orderflow"] = self.orderflow_provider(ticker)
@@ -60,9 +75,58 @@ class EventScreenEngine(BaseScreenEngine):
             symbol=ticker,
             instrument_tz=params.tz or self.default_tz,
             orderflow=context.get("orderflow"),
+            use_gpu=context.get("use_gpu", False),
+            gpu_device_id=context.get("gpu_device_id", 0),
         )
         return {
             "stats": result.summary,
             "patterns": result.patterns,
             "metadata": {"events": result.events},
         }
+
+    def _generate_events_from_definitions(
+        self,
+        ticker: str,
+        data: pd.DataFrame,
+        params: BaseScreenParams,
+    ) -> pd.DataFrame:
+        if not isinstance(params, EventParams):
+            return pd.DataFrame()
+
+        event_defs = list(self.event_definitions.get(ticker, []))
+        if not event_defs:
+            event_defs = get_events_for_ticker(ticker)
+
+        if params.event_code:
+            event_defs = [
+                ed for ed in event_defs if ed.code == params.event_code
+            ] or event_defs
+
+        if not event_defs:
+            return pd.DataFrame()
+
+        sessions = self._extract_session_dates(data, params.tz or self.default_tz)
+        rows: List[Dict[str, Any]] = []
+        for event_def in event_defs:
+            for session_date in sessions:
+                if not is_matching_event_slot(session_date, event_def):
+                    continue
+                release_ts = event_release_dt_for_date(event_def, session_date, params.tz or self.default_tz)
+                rows.append({
+                    "event_code": event_def.code,
+                    "release_ts": release_ts,
+                })
+
+        if not rows:
+            return pd.DataFrame()
+        df = pd.DataFrame(rows).drop_duplicates().sort_values("release_ts").reset_index(drop=True)
+        return df
+
+    @staticmethod
+    def _extract_session_dates(data: pd.DataFrame, instrument_tz: str) -> List[date]:
+        if "ts" in data.columns:
+            ts = pd.to_datetime(data["ts"])
+        else:
+            ts = pd.to_datetime(data.index)
+        ts = ts.dt.tz_localize(instrument_tz) if ts.dt.tz is None else ts.dt.tz_convert(instrument_tz)
+        return sorted(ts.dt.date.unique())


### PR DESCRIPTION
## Summary
- enable event screen engine to build calendars from EventDefinition schedules when explicit calendars are missing
- add optional GPU-backed calculations to the event screener and propagate GPU settings from HistoricalScreenerV2
- make HistoricalScreenerV2 GPU-aware when resolving worker counts and logging availability

## Testing
- python -m pytest test_relative_imports.py *(fails: missing `module_path` fixture in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e17c2b668832a95b29c9ed5e0d49f)