### PR TITLE
Add time predictive gates and preserve decision timestamps

### DIFF
--- a/CTAFlow/strategy/prediction_to_position.py
+++ b/CTAFlow/strategy/prediction_to_position.py
@@ -93,9 +93,9 @@ class PredictionToPosition:
         base_rows["returns_y"] = agg_returns["returns_y_mean"]
         base_rows["prediction_position"] = agg_scores["prediction_position"]
 
-        # Cleanup temporary columns
+        # Cleanup temporary columns while preserving decision timestamps
         result = base_rows.drop(columns=["_ptp_score", "_is_bias", "_bias_score", "_other_score"], errors="ignore")
-        return result.reset_index(drop=True)
+        return result.reset_index()
 
     def resolve(
         self,

--- a/CTAFlow/strategy/screener_pipeline.py
+++ b/CTAFlow/strategy/screener_pipeline.py
@@ -1735,9 +1735,13 @@ class ScreenerPipeline:
         if pattern_type in {"weekday_mean", "weekday_returns"}:
             return self._extract_weekday_mean(df, payload, key, months)
         if pattern_type == "time_predictive_nextday":
-            return self._extract_time_nextday(df, payload, key, months)
+            return self._extract_time_nextday(df, payload, key, months, pattern)
         if pattern_type == "time_predictive_nextweek":
-            return self._extract_time_nextweek(df, payload, key, months)
+            return self._extract_time_nextweek(df, payload, key, months, pattern)
+        if pattern_type == "time_predictive_eod":
+            return self._extract_time_eod(df, payload, key, months, pattern)
+        if pattern_type == "time_predictive_intraday":
+            return self._extract_time_intraday(df, payload, key, months, pattern)
         if pattern_type == "weekend_hedging":
             return self._extract_weekend_hedging(df, pattern, payload, key, months)
 
@@ -2070,8 +2074,13 @@ class ScreenerPipeline:
         payload: Mapping[str, Any],
         key: Optional[str],
         months: Optional[List[int]],
+        pattern: Optional[Mapping[str, Any]] = None,
     ) -> List[str]:
-        hms, hmsf = self._time_to_strings(payload.get("time"))
+        time_value = payload.get("time") if payload else None
+        if time_value is None and pattern is not None:
+            time_value = pattern.get("time")
+
+        hms, hmsf = self._time_to_strings(time_value)
         if hms is None:
             return []
 
@@ -2096,8 +2105,13 @@ class ScreenerPipeline:
         payload: Mapping[str, Any],
         key: Optional[str],
         months: Optional[List[int]],
+        pattern: Optional[Mapping[str, Any]] = None,
     ) -> List[str]:
-        hms, hmsf = self._time_to_strings(payload.get("time"))
+        time_value = payload.get("time") if payload else None
+        if time_value is None and pattern is not None:
+            time_value = pattern.get("time")
+
+        hms, hmsf = self._time_to_strings(time_value)
         if hms is None:
             return []
 
@@ -2121,6 +2135,79 @@ class ScreenerPipeline:
             "correlation": payload.get("correlation"),
             "p": payload.get("p_value"),
             "strongest_days": list(strongest_days) if strongest_days else None,
+        }
+        return self._add_feature(df, base, mask, sidecars)
+
+    def _extract_time_eod(
+        self,
+        df: pd.DataFrame,
+        payload: Mapping[str, Any],
+        key: Optional[str],
+        months: Optional[List[int]],
+        pattern: Optional[Mapping[str, Any]] = None,
+    ) -> List[str]:
+        raw_time = payload.get("time") if payload else None
+        if raw_time is None and pattern is not None:
+            raw_time = pattern.get("time")
+        if isinstance(raw_time, str) and "->" in raw_time:
+            raw_time = raw_time.split("->", 1)[0].strip()
+
+        hms, hmsf = self._time_to_strings(raw_time)
+        if hms is None:
+            return []
+
+        use_us = self._use_microseconds(df, raw_time)
+        column = "clock_time_us" if use_us else "clock_time"
+        target = hmsf if use_us else hms
+
+        mask = df[column] == target
+        mask &= self._months_mask(df, months)
+
+        base = self._feature_base_name(key, f"time_eod_{target}")
+        sidecars = {
+            "time": pattern.get("time") if pattern is not None else payload.get("time"),
+            "correlation": payload.get("correlation"),
+            "p": payload.get("p_value"),
+            "period_length_min": payload.get("period_length_min"),
+        }
+        return self._add_feature(df, base, mask, sidecars)
+
+    def _extract_time_intraday(
+        self,
+        df: pd.DataFrame,
+        payload: Mapping[str, Any],
+        key: Optional[str],
+        months: Optional[List[int]],
+        pattern: Optional[Mapping[str, Any]] = None,
+    ) -> List[str]:
+        raw_time = payload.get("time") if payload else None
+        if raw_time is None and pattern is not None:
+            raw_time = pattern.get("time")
+        predictor_time: Any = raw_time
+        response_time: Optional[str] = None
+        if isinstance(raw_time, str) and "->" in raw_time:
+            predictor_time, response_time = [part.strip() for part in raw_time.split("->", 1)]
+
+        hms, hmsf = self._time_to_strings(predictor_time)
+        if hms is None:
+            return []
+
+        use_us = self._use_microseconds(df, predictor_time)
+        column = "clock_time_us" if use_us else "clock_time"
+        target = hmsf if use_us else hms
+
+        mask = df[column] == target
+        mask &= self._months_mask(df, months)
+
+        base = self._feature_base_name(key, f"time_intraday_{target}")
+        sidecars = {
+            "time": pattern.get("time") if pattern is not None else payload.get("time"),
+            "predictor_time": predictor_time,
+            "response_time": response_time,
+            "correlation": payload.get("correlation"),
+            "p": payload.get("p_value"),
+            "n": payload.get("n"),
+            "period_length_min": payload.get("period_length_min"),
         }
         return self._add_feature(df, base, mask, sidecars)
 
@@ -3701,6 +3788,10 @@ class HorizonMapper:
                     branch = precomputed_payload.get("next_day")
                 elif pattern_type == "time_predictive_nextweek":
                     branch = precomputed_payload.get("next_week")
+                elif pattern_type == "time_predictive_eod":
+                    branch = precomputed_payload.get("eod")
+                elif pattern_type == "time_predictive_intraday":
+                    branch = precomputed_payload.get("intraday")
                 else:
                     branch = None
 


### PR DESCRIPTION
## Summary
- add screener gate extraction for time_predictive_eod and time_predictive_intraday patterns using top-level time metadata
- ensure PredictionToPosition aggregate output retains ts_decision values

## Testing
- python -m pytest tests/test_backtester_logic.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939dd383a7c832ab0244099db49538b)