### PR TITLE
Handle intraday windows and filter overlapping target times

### DIFF
--- a/CTAFlow/screeners/seasonality_engine.py
+++ b/CTAFlow/screeners/seasonality_engine.py
@@ -52,6 +52,7 @@ class SeasonalityScreenEngine(BaseScreenEngine):
         )
         results = screener.st_seasonality_screen(
             target_times=params.target_times or [],
+            min_target_spacing_minutes=params.min_target_spacing_minutes,
             period_length=params.period_length,
             dayofweek_screen=params.dayofweek_screen,
             months=params.months,

--- a/CTAFlow/strategy/prediction_to_position.py
+++ b/CTAFlow/strategy/prediction_to_position.py
@@ -93,9 +93,9 @@ class PredictionToPosition:
         base_rows["returns_y"] = agg_returns["returns_y_mean"]
         base_rows["prediction_position"] = agg_scores["prediction_position"]
 
-        # Cleanup temporary columns
+        # Cleanup temporary columns while preserving decision timestamps
         result = base_rows.drop(columns=["_ptp_score", "_is_bias", "_bias_score", "_other_score"], errors="ignore")
-        return result.reset_index(drop=True)
+        return result.reset_index()
 
     def resolve(
         self,

--- a/tests/test_intraday_response_windows.py
+++ b/tests/test_intraday_response_windows.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pandas as pd
+from datetime import time
+
+from CTAFlow.screeners.historical_screener import HistoricalScreener
+from CTAFlow.strategy.screener_pipeline import HorizonMapper, ScreenerPipeline
+
+
+def test_intraday_response_window_changes_returns():
+    ts = pd.date_range(
+        "2024-01-01 09:30",
+        periods=3,
+        freq="30min",
+        tz="America/Chicago",
+    )
+    df = pd.DataFrame(
+        {
+            "ts": ts,
+            "open": [100.0, 110.0, 90.0],
+            "close": [100.0, 110.0, 80.0],
+            "session_id": [1, 1, 1],
+        }
+    )
+
+    patterns = {
+        "short": {
+            "pattern_type": "time_predictive_intraday",
+            "time": "09:30 -> 10:00",
+            "pattern_payload": {
+                "time": "09:30 -> 10:00",
+                "correlation": 0.5,
+                "period_length_min": 30,
+            },
+        },
+        "long": {
+            "pattern_type": "time_predictive_intraday",
+            "time": "09:30 -> 10:30",
+            "pattern_payload": {
+                "time": "09:30 -> 10:30",
+                "correlation": 0.5,
+                "period_length_min": 60,
+            },
+        },
+    }
+
+    pipeline = ScreenerPipeline(use_gpu=False, tz="America/Chicago", time_match="hms")
+    features = pipeline.build_features(df, patterns)
+    horizon_mapper = HorizonMapper(tz="America/Chicago", time_match="second")
+    xy = horizon_mapper.build_xy(
+        features,
+        patterns,
+        default_intraday_minutes=30,
+        predictor_minutes=30,
+    )
+
+    short_return = float(xy.loc[xy["gate"].str.contains("short"), "returns_y"].iloc[0])
+    long_return = float(xy.loc[xy["gate"].str.contains("long"), "returns_y"].iloc[0])
+
+    assert short_return != long_return
+    assert not np.isnan(short_return)
+    assert not np.isnan(long_return)
+
+
+def test_min_spacing_filters_overlapping_target_times():
+    clocks = [time(2, 30), time(2, 40), time(3, 0)]
+
+    filtered = HistoricalScreener._filter_times_by_spacing(clocks, min_spacing_minutes=30)
+
+    assert [c.strftime("%H:%M") for c in filtered] == ["02:30", "03:00"]


### PR DESCRIPTION
## Summary
- derive intraday response windows from per-pattern start/end times so gates with shared predictors no longer reuse the same horizon
- allow seasonality screening to filter overlapping target times via a configurable minimum spacing and propagate the parameter through the seasonality engine
- add regression tests covering per-pattern intraday deltas and minimum target-time spacing

## Testing
- python -m pytest tests/test_intraday_response_windows.py tests/test_backtester_logic.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939dd383a7c832ab0244099db49538b)