### PR TITLE
Preserve CTALight utilities in IntradayMomentumLight wrapper

### DIFF
--- a/CTAFlow/models/intraday_momentum.py
+++ b/CTAFlow/models/intraday_momentum.py
@@ -66,6 +66,14 @@ class IntradayMomentumLight:
 
         return
 
+    def __getattr__(self, item):
+        """Delegate missing attributes to the configured base model."""
+
+        model = self._get_model()
+        if hasattr(model, item):
+            return getattr(model, item)
+        raise AttributeError(f"{self.__class__.__name__} object has no attribute '{item}'")
+
     def _resolve_model_class(self) -> Type[object]:
         if isinstance(self.base_model, str):
             try:


### PR DESCRIPTION
## Summary
- delegate missing attribute access from IntradayMomentumLight to the configured base model to retain CTALight APIs when wrapping other models

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3bdbf120832a9bbb69868e154c4a)