### PR TITLE
Reset index and exclude datetime dtypes from summary feature selection

### DIFF
--- a/CTAFlow/data/model_datasets.py
+++ b/CTAFlow/data/model_datasets.py
@@ -126,11 +126,13 @@ class DualDataset(Dataset):
 
         self.df_summary[date_col] = pd.to_datetime(self.df_summary[date_col])
         self.df_summary['date'] = self.df_summary[date_col].dt.date
+        self.df_summary = self.df_summary.reset_index(drop=True)
 
-        # Identify feature columns (exclude date/target columns)
+        # Identify feature columns (exclude date/target/datetime columns)
         exclude_cols = [date_col, 'date', 'Target', target_col] if target_col else [date_col, 'date', 'Target']
         exclude_cols = [c for c in exclude_cols if c is not None]
-        self.feature_cols = [c for c in self.df_summary.columns if c not in exclude_cols]
+        candidate_features = self.df_summary.select_dtypes(exclude=['datetime']).columns
+        self.feature_cols = [c for c in candidate_features if c not in exclude_cols]
         self.features = self.df_summary[self.feature_cols].values.astype(np.float32)
 
         # 2. Process Target Data


### PR DESCRIPTION
### Motivation
- Prevent datetime values from leaking into feature arrays when the summary data has a `DatetimeIndex` or datetime-like columns.
- Ensure the derived `date` column does not leave a `DatetimeIndex` on the DataFrame used for feature selection.

### Description
- After creating the `date` column the summary DataFrame is reset with `self.df_summary = self.df_summary.reset_index(drop=True)` to remove any `DatetimeIndex`.
- Feature candidates are now taken with `self.df_summary.select_dtypes(exclude=['datetime']).columns` to exclude datetime-typed columns.
- `self.feature_cols` is computed by filtering those candidate columns against the existing exclusion list (`date`, `Target`, `target_col`).
- Feature values are still converted to `np.float32` via `self.features = self.df_summary[self.feature_cols].values.astype(np.float32)`.

### Testing
- No automated tests were executed for this change.
- The change was committed and prepared for a PR but no CI run was requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602fe844a0832a9e46e7d689727e1f)