### PR TITLE
Add Dash app skeleton with Parquet/S3 storage infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,15 @@ Concise guide for working on CTAFlow, a CTA positioning and orderflow analysis t
 - **Features (`CTAFlow/features/`)**: `signals_processing.py` builds COT + technical indicators; `feature_engineering.py` covers intraday microstructure; `curve_analysis.py` unifies curve shape/evolution analysis.
 - **Containers (`CTAFlow/data/contract_handling/`)**: `SpreadData`, `FuturesCurve`, `Contract`, and friends provide numpy-backed curve slices.
 - **Forecasting (`CTAFlow/forecaster/forecast.py`)**: family of CTA models with selective indicator calculation and weekly resampling.
+- **Models (`CTAFlow/models/`)**: `base_models.py` contains `CTAForecast` orchestrator with COT/technical feature preparation and model training; `pattern_forecast.py` builds ML-ready datasets for pattern prediction; `volatility.py` provides HAR-style realised-volatility forecasting; `intraday_momentum.py` handles intraday momentum signals. WSPR models in `dual_model.py` (when added) will provide dual-model ensemble forecasting.
 - **Strategy (`CTAFlow/strategy/`)**: `screener_pipeline.py` normalises screener payloads into gate columns; keep `_items_from_patterns` compatible with nested mappings and `PatternExtractor.concat_many` outputs. `HorizonMapper.build_xy` expects timezone-aware `ts`, `open`, `close`, `session_id` columns.
 - **Screeners (`CTAFlow/screeners/`)**: `pattern_extractor.py` preserves `SUMMARY_COLUMNS`, `_strength_raw`, and async loaders; `orderflow_screen.py` provides orderflow seasonality metrics.
+
+## Dashboard app (`app/`)
+- **Structure**: `app/` contains the Dash frontend; `app/results/` stores model outputs.
+- **Storage**: Parquet is the preferred format for model results and intermediate data; use `pyarrow` or `fastparquet`.
+- **AWS S3**: Data downloads handled via `app/storage/s3_client.py`; credentials loaded from environment or `~/.aws/credentials`.
+- **Existing apps**: `CTAFlow/apps/cot_dashboard.py` provides a reference Dash implementation for COT feature visualization.
 
 ## Working notes
 - Seasonal/orderflow outputs feed downstream notebooks; avoid changing canonical column names or shapes.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,8 @@
+"""CTAFlow Dashboard Application.
+
+A Python Dash frontend for CTA positioning and orderflow analysis.
+"""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/app/callbacks/__init__.py
+++ b/app/callbacks/__init__.py
@@ -1,0 +1,18 @@
+"""Callback handlers for the CTAFlow dashboard."""
+
+from __future__ import annotations
+
+from dash import Dash, Input, Output, html
+
+from . import tab_callbacks
+
+
+def register_callbacks(app: Dash) -> None:
+    """Register all callbacks with the Dash application.
+
+    Parameters
+    ----------
+    app : Dash
+        The Dash application instance.
+    """
+    tab_callbacks.register(app)

--- a/app/callbacks/tab_callbacks.py
+++ b/app/callbacks/tab_callbacks.py
@@ -1,0 +1,66 @@
+"""Tab navigation callbacks."""
+
+from __future__ import annotations
+
+from dash import Dash, Input, Output, html
+
+
+def register(app: Dash) -> None:
+    """Register tab navigation callbacks.
+
+    Parameters
+    ----------
+    app : Dash
+        The Dash application instance.
+    """
+
+    @app.callback(
+        Output("tab-content", "children"),
+        Input("main-tabs", "value"),
+    )
+    def render_tab_content(tab: str) -> html.Div:
+        """Render content based on selected tab.
+
+        Parameters
+        ----------
+        tab : str
+            The selected tab value.
+
+        Returns
+        -------
+        html.Div
+            Content component for the selected tab.
+        """
+        if tab == "overview":
+            return html.Div(
+                [
+                    html.H2("Overview"),
+                    html.P("Select a ticker to view analysis."),
+                ],
+                className="tab-content",
+            )
+        elif tab == "screeners":
+            return html.Div(
+                [
+                    html.H2("Screeners"),
+                    html.P("Pattern and orderflow screeners."),
+                ],
+                className="tab-content",
+            )
+        elif tab == "models":
+            return html.Div(
+                [
+                    html.H2("Models"),
+                    html.P("Forecasting models and training."),
+                ],
+                className="tab-content",
+            )
+        elif tab == "results":
+            return html.Div(
+                [
+                    html.H2("Results"),
+                    html.P("Model results and analysis."),
+                ],
+                className="tab-content",
+            )
+        return html.Div("Select a tab")

--- a/app/components/__init__.py
+++ b/app/components/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable UI components for the CTAFlow dashboard."""

--- a/app/layouts/__init__.py
+++ b/app/layouts/__init__.py
@@ -1,0 +1,5 @@
+"""Layout components for the CTAFlow dashboard."""
+
+from . import main_layout
+
+__all__ = ["main_layout"]

--- a/app/layouts/main_layout.py
+++ b/app/layouts/main_layout.py
@@ -1,0 +1,49 @@
+"""Main dashboard layout definition."""
+
+from __future__ import annotations
+
+from dash import html, dcc
+
+
+def get_layout() -> html.Div:
+    """Build the main dashboard layout.
+
+    Returns
+    -------
+    html.Div
+        Root layout component containing navigation and content areas.
+    """
+    return html.Div(
+        [
+            # Header
+            html.Div(
+                [
+                    html.H1("CTAFlow Dashboard", className="header-title"),
+                    html.P(
+                        "CTA Positioning and Orderflow Analysis",
+                        className="header-subtitle",
+                    ),
+                ],
+                className="header",
+            ),
+            # Navigation tabs
+            dcc.Tabs(
+                id="main-tabs",
+                value="overview",
+                children=[
+                    dcc.Tab(label="Overview", value="overview"),
+                    dcc.Tab(label="Screeners", value="screeners"),
+                    dcc.Tab(label="Models", value="models"),
+                    dcc.Tab(label="Results", value="results"),
+                ],
+                className="main-tabs",
+            ),
+            # Content area
+            html.Div(id="tab-content", className="content"),
+            # Data stores
+            dcc.Store(id="selected-ticker-store"),
+            dcc.Store(id="date-range-store"),
+            dcc.Store(id="results-store"),
+        ],
+        className="app-container",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+"""Main Dash application entry point.
+
+Usage
+-----
+Run the app with::
+
+    python -m app.main
+
+Or import and run programmatically::
+
+    from app import create_app
+    app = create_app()
+    app.run(debug=True)
+"""
+
+from __future__ import annotations
+
+from dash import Dash, html, dcc
+from .layouts import main_layout
+from .callbacks import register_callbacks
+
+
+def create_app(debug: bool = False) -> Dash:
+    """Create and configure the Dash application.
+
+    Parameters
+    ----------
+    debug : bool
+        Whether to run in debug mode with hot reloading.
+
+    Returns
+    -------
+    Dash
+        Configured Dash application instance.
+    """
+    app = Dash(
+        __name__,
+        suppress_callback_exceptions=True,
+        title="CTAFlow Dashboard",
+    )
+
+    app.layout = main_layout.get_layout()
+    register_callbacks(app)
+
+    return app
+
+
+def main() -> None:
+    """Run the dashboard application."""
+    app = create_app(debug=True)
+    app.run(debug=True, host="0.0.0.0", port=8050)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/results/.gitkeep
+++ b/app/results/.gitkeep
@@ -1,0 +1,1 @@
+# Results directory for model outputs (Parquet format)

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,0 +1,9 @@
+"""Storage utilities for the CTAFlow dashboard.
+
+Provides Parquet I/O and AWS S3 integration for model data storage.
+"""
+
+from .parquet_store import ParquetStore
+from .s3_client import S3DataClient
+
+__all__ = ["ParquetStore", "S3DataClient"]

--- a/app/storage/parquet_store.py
+++ b/app/storage/parquet_store.py
@@ -1,0 +1,177 @@
+"""Parquet storage utilities for model results and intermediate data.
+
+This module provides a unified interface for reading and writing Parquet files,
+which is the preferred storage format for CTAFlow model outputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+
+# Default results directory
+DEFAULT_RESULTS_PATH = Path(__file__).resolve().parent.parent / "results"
+
+
+class ParquetStore:
+    """Parquet storage manager for model results.
+
+    Parameters
+    ----------
+    base_path : Path or str, optional
+        Base directory for Parquet files. Defaults to app/results.
+    """
+
+    def __init__(self, base_path: Optional[Union[Path, str]] = None) -> None:
+        self.base_path = Path(base_path) if base_path else DEFAULT_RESULTS_PATH
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def save(
+        self,
+        df: pd.DataFrame,
+        name: str,
+        *,
+        partition_cols: Optional[List[str]] = None,
+        compression: str = "snappy",
+    ) -> Path:
+        """Save a DataFrame to Parquet format.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame to save.
+        name : str
+            Name for the Parquet file (without extension).
+        partition_cols : List[str], optional
+            Columns to partition by (creates directory structure).
+        compression : str
+            Compression algorithm. Default is 'snappy'.
+
+        Returns
+        -------
+        Path
+            Path to the saved Parquet file or directory.
+        """
+        file_path = self.base_path / f"{name}.parquet"
+
+        if partition_cols:
+            # Partitioned write creates a directory
+            df.to_parquet(
+                file_path,
+                partition_cols=partition_cols,
+                compression=compression,
+                engine="pyarrow",
+            )
+        else:
+            df.to_parquet(
+                file_path,
+                compression=compression,
+                engine="pyarrow",
+            )
+
+        return file_path
+
+    def load(
+        self,
+        name: str,
+        *,
+        columns: Optional[List[str]] = None,
+        filters: Optional[List] = None,
+    ) -> pd.DataFrame:
+        """Load a DataFrame from Parquet format.
+
+        Parameters
+        ----------
+        name : str
+            Name of the Parquet file (without extension).
+        columns : List[str], optional
+            Specific columns to load. Loads all if None.
+        filters : List, optional
+            Row group filters for partitioned data.
+
+        Returns
+        -------
+        pd.DataFrame
+            Loaded DataFrame.
+        """
+        file_path = self.base_path / f"{name}.parquet"
+
+        return pd.read_parquet(
+            file_path,
+            columns=columns,
+            filters=filters,
+            engine="pyarrow",
+        )
+
+    def list_results(self, pattern: str = "*.parquet") -> List[Path]:
+        """List available Parquet files.
+
+        Parameters
+        ----------
+        pattern : str
+            Glob pattern for matching files.
+
+        Returns
+        -------
+        List[Path]
+            List of matching Parquet file paths.
+        """
+        return list(self.base_path.glob(pattern))
+
+    def delete(self, name: str) -> bool:
+        """Delete a Parquet file.
+
+        Parameters
+        ----------
+        name : str
+            Name of the Parquet file (without extension).
+
+        Returns
+        -------
+        bool
+            True if file was deleted, False if it didn't exist.
+        """
+        file_path = self.base_path / f"{name}.parquet"
+
+        if file_path.exists():
+            if file_path.is_dir():
+                import shutil
+
+                shutil.rmtree(file_path)
+            else:
+                file_path.unlink()
+            return True
+        return False
+
+    def save_model_results(
+        self,
+        results: Dict[str, pd.DataFrame],
+        model_name: str,
+        *,
+        compression: str = "snappy",
+    ) -> Dict[str, Path]:
+        """Save multiple DataFrames as model results.
+
+        Parameters
+        ----------
+        results : Dict[str, pd.DataFrame]
+            Dictionary mapping result names to DataFrames.
+        model_name : str
+            Name of the model (used as prefix).
+        compression : str
+            Compression algorithm.
+
+        Returns
+        -------
+        Dict[str, Path]
+            Dictionary mapping result names to saved file paths.
+        """
+        saved_paths = {}
+        for result_name, df in results.items():
+            full_name = f"{model_name}_{result_name}"
+            saved_paths[result_name] = self.save(
+                df, full_name, compression=compression
+            )
+        return saved_paths

--- a/app/storage/s3_client.py
+++ b/app/storage/s3_client.py
@@ -1,0 +1,285 @@
+"""AWS S3 client for downloading model data.
+
+This module provides utilities for downloading data stored on AWS S3 that is
+used by CTAFlow models. Credentials are loaded from environment variables
+or the standard AWS credentials file (~/.aws/credentials).
+
+Environment Variables
+--------------------
+AWS_ACCESS_KEY_ID : str
+    AWS access key ID.
+AWS_SECRET_ACCESS_KEY : str
+    AWS secret access key.
+AWS_DEFAULT_REGION : str, optional
+    Default AWS region. Defaults to 'us-east-1'.
+CTAFLOW_S3_BUCKET : str, optional
+    Default S3 bucket name for CTAFlow data.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+import pandas as pd
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError, NoCredentialsError
+
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+    boto3 = None
+    ClientError = Exception
+    NoCredentialsError = Exception
+
+
+DEFAULT_BUCKET = os.environ.get("CTAFLOW_S3_BUCKET", "ctaflow-data")
+DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+
+class S3DataClient:
+    """S3 client for downloading CTAFlow model data.
+
+    Parameters
+    ----------
+    bucket : str, optional
+        S3 bucket name. Defaults to CTAFLOW_S3_BUCKET env var or 'ctaflow-data'.
+    region : str, optional
+        AWS region. Defaults to AWS_DEFAULT_REGION env var or 'us-east-1'.
+    local_cache_path : Path or str, optional
+        Local directory for caching downloaded files.
+    """
+
+    def __init__(
+        self,
+        bucket: Optional[str] = None,
+        region: Optional[str] = None,
+        local_cache_path: Optional[Union[Path, str]] = None,
+    ) -> None:
+        if not HAS_BOTO3:
+            raise ImportError(
+                "boto3 is required for S3 support. Install with: pip install boto3"
+            )
+
+        self.bucket = bucket or DEFAULT_BUCKET
+        self.region = region or DEFAULT_REGION
+        self.local_cache_path = (
+            Path(local_cache_path)
+            if local_cache_path
+            else Path(__file__).resolve().parent.parent / "results" / ".s3_cache"
+        )
+        self.local_cache_path.mkdir(parents=True, exist_ok=True)
+
+        self._client = None
+        self._resource = None
+
+    @property
+    def client(self):
+        """Lazily initialize and return the S3 client."""
+        if self._client is None:
+            self._client = boto3.client("s3", region_name=self.region)
+        return self._client
+
+    @property
+    def resource(self):
+        """Lazily initialize and return the S3 resource."""
+        if self._resource is None:
+            self._resource = boto3.resource("s3", region_name=self.region)
+        return self._resource
+
+    def download_file(
+        self,
+        s3_key: str,
+        local_path: Optional[Union[Path, str]] = None,
+        *,
+        use_cache: bool = True,
+    ) -> Path:
+        """Download a file from S3.
+
+        Parameters
+        ----------
+        s3_key : str
+            S3 object key (path within the bucket).
+        local_path : Path or str, optional
+            Local path to save the file. Defaults to cache directory.
+        use_cache : bool
+            If True, skip download if file exists locally.
+
+        Returns
+        -------
+        Path
+            Path to the downloaded file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the S3 object does not exist.
+        PermissionError
+            If AWS credentials are invalid or missing.
+        """
+        if local_path is None:
+            local_path = self.local_cache_path / s3_key.replace("/", "_")
+        else:
+            local_path = Path(local_path)
+
+        if use_cache and local_path.exists():
+            return local_path
+
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            self.client.download_file(self.bucket, s3_key, str(local_path))
+        except NoCredentialsError as e:
+            raise PermissionError(
+                "AWS credentials not found. Set AWS_ACCESS_KEY_ID and "
+                "AWS_SECRET_ACCESS_KEY environment variables or configure "
+                "~/.aws/credentials"
+            ) from e
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "404":
+                raise FileNotFoundError(
+                    f"S3 object not found: s3://{self.bucket}/{s3_key}"
+                ) from e
+            raise
+
+        return local_path
+
+    def download_parquet(
+        self,
+        s3_key: str,
+        *,
+        use_cache: bool = True,
+        columns: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
+        """Download and read a Parquet file from S3.
+
+        Parameters
+        ----------
+        s3_key : str
+            S3 object key for the Parquet file.
+        use_cache : bool
+            If True, use cached file if available.
+        columns : List[str], optional
+            Specific columns to load.
+
+        Returns
+        -------
+        pd.DataFrame
+            Loaded DataFrame.
+        """
+        local_path = self.download_file(s3_key, use_cache=use_cache)
+        return pd.read_parquet(local_path, columns=columns, engine="pyarrow")
+
+    def list_objects(
+        self, prefix: str = "", suffix: str = ""
+    ) -> List[str]:
+        """List objects in the S3 bucket.
+
+        Parameters
+        ----------
+        prefix : str
+            Filter objects by key prefix.
+        suffix : str
+            Filter objects by key suffix.
+
+        Returns
+        -------
+        List[str]
+            List of S3 object keys.
+        """
+        paginator = self.client.get_paginator("list_objects_v2")
+        keys = []
+
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if suffix and not key.endswith(suffix):
+                    continue
+                keys.append(key)
+
+        return keys
+
+    def list_parquet_files(self, prefix: str = "") -> List[str]:
+        """List Parquet files in the S3 bucket.
+
+        Parameters
+        ----------
+        prefix : str
+            Filter by key prefix.
+
+        Returns
+        -------
+        List[str]
+            List of Parquet file keys.
+        """
+        return self.list_objects(prefix=prefix, suffix=".parquet")
+
+    def upload_file(
+        self,
+        local_path: Union[Path, str],
+        s3_key: str,
+    ) -> str:
+        """Upload a file to S3.
+
+        Parameters
+        ----------
+        local_path : Path or str
+            Local file path to upload.
+        s3_key : str
+            S3 object key (destination path).
+
+        Returns
+        -------
+        str
+            S3 URI of the uploaded file.
+        """
+        self.client.upload_file(str(local_path), self.bucket, s3_key)
+        return f"s3://{self.bucket}/{s3_key}"
+
+    def upload_parquet(
+        self,
+        df: pd.DataFrame,
+        s3_key: str,
+        *,
+        compression: str = "snappy",
+    ) -> str:
+        """Save a DataFrame to Parquet and upload to S3.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame to upload.
+        s3_key : str
+            S3 object key for the Parquet file.
+        compression : str
+            Compression algorithm.
+
+        Returns
+        -------
+        str
+            S3 URI of the uploaded file.
+        """
+        local_path = self.local_cache_path / s3_key.replace("/", "_")
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        df.to_parquet(local_path, compression=compression, engine="pyarrow")
+        return self.upload_file(local_path, s3_key)
+
+    def clear_cache(self) -> int:
+        """Clear the local cache directory.
+
+        Returns
+        -------
+        int
+            Number of files deleted.
+        """
+        import shutil
+
+        count = sum(1 for _ in self.local_cache_path.iterdir())
+        shutil.rmtree(self.local_cache_path)
+        self.local_cache_path.mkdir(parents=True, exist_ok=True)
+        return count

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,10 @@ dash>=2.0.0
 # Data storage and I/O
 tables>=3.6.0  # For HDF5 support
 toml>=0.10.0   # For configuration files
+pyarrow>=10.0.0  # For Parquet support (preferred storage format)
+
+# AWS S3 integration (optional)
+boto3>=1.26.0  # AWS SDK for S3 data downloads
 
 # Utilities
 tqdm>=4.60.0   # Progress bars


### PR DESCRIPTION
- Create app/ directory structure for Python Dash frontend
- Add main.py entry point with tab-based navigation layout
- Implement ParquetStore for model results storage (preferred format)
- Add S3DataClient for AWS S3 data downloads with local caching
- Create app/results/ directory for model outputs
- Update CLAUDE.md with models documentation and dashboard app section
- Add pyarrow and boto3 dependencies to requirements.txt

https://claude.ai/code/session_01WVehY1R16h8ZPdEmejGsB7