### PR TITLE
Fix batch-size dimension mismatch in ContinuousTradingLoss

### DIFF
--- a/CTAFlow/models/deep_learning/training/loss/clf.py
+++ b/CTAFlow/models/deep_learning/training/loss/clf.py
@@ -836,16 +836,26 @@ class ContinuousTradingLoss(nn.Module):
         pos = position.squeeze()
         ret = forward_return.squeeze()
 
-        # ── Turnover ────────────────────────────────────────────────
+        # ── Squeeze prev_position once & handle batch-size mismatch
+        #    (last batch may be smaller than the preceding one)
         if prev_position is not None:
-            turnover = (pos - prev_position.squeeze()).abs().mean()
+            prev = prev_position.squeeze()
+            n = min(pos.shape[0], prev.shape[0])
+            prev = prev[:n]
+        else:
+            prev = None
+
+        # ── Turnover ────────────────────────────────────────────────
+        if prev is not None:
+            turnover = (pos[:n] - prev).abs().mean()
         else:
             turnover = pos.abs().mean()
 
         # ── 1. Risk-adjusted return (gross or TC-adjusted) ─────────
         gross_ret = pos * ret
-        if self.tc_in_sharpe and prev_position is not None:
-            tc_drag = self.tc_cost * (pos - prev_position.squeeze()).abs()
+        if self.tc_in_sharpe and prev is not None:
+            tc_drag = torch.zeros_like(pos)
+            tc_drag[:n] = self.tc_cost * (pos[:n] - prev).abs()
             strategy_ret = gross_ret - tc_drag
         else:
             strategy_ret = gross_ret
@@ -877,8 +887,8 @@ class ContinuousTradingLoss(nn.Module):
 
         # ── 5. Holding bonus (reward position persistence) ─────────
         loss_holding = torch.tensor(0.0, device=pos.device)
-        if self.holding_weight > 0 and prev_position is not None:
-            agreement = (pos * prev_position.squeeze()).clamp(min=0).mean()
+        if self.holding_weight > 0 and prev is not None:
+            agreement = (pos[:n] * prev).clamp(min=0).mean()
             loss_holding = -self.holding_weight * agreement
 
         total = (


### PR DESCRIPTION
When prev_position is tracked across batches in train_epoch_v3_ptp, the last batch may be smaller than the preceding one (e.g., 92 vs 96), causing a RuntimeError on subtraction. Squeeze prev_position once upfront and truncate to min(current, previous) batch size for turnover, tc_drag, and holding bonus computations.

https://claude.ai/code/session_01LQkVN2Xc9yybn4gEyesDYx